### PR TITLE
CI progresses much better with certora-cli-beta v6.0.0 compared to certora-cli v5.0.5

### DIFF
--- a/.github/workflows/certora.yml
+++ b/.github/workflows/certora.yml
@@ -60,35 +60,35 @@ jobs:
       matrix:
         rule:
           # - AToken.conf
-          # - PoolInvariant.conf --msg "Martins rules with PoolInvariant.conf" --rule "borrowOnlyVariableOrStableRate"
-          # - PoolInvariant.conf --msg "Index non decreasing part 1" --rule "indexIncreasesMonotonically"
+          - PoolInvariant.conf --msg "Martins rules with PoolInvariant.conf" --rule "borrowOnlyVariableOrStableRate"
+          - PoolInvariant.conf --msg "Index non decreasing part 1" --rule "indexIncreasesMonotonically"
           - PoolAccurate.conf --msg "Index non decreasing part 3" --rule "indexChangesOnlyWith_updateIndexes" # TIMEOUT 2023
-          # - PoolAccurate.conf --msg "Index non decreasing part 4" --rule "liquidityIndexNonDecresingFor_cumulateToLiquidityIndex"
-          # # - PoolAccurate.conf --msg "Deposit updates AToken scaled balance part 1" --rule "depositUpdatesUserATokenSuperBalance" # TIMEOUT 2023
-          # # - PoolAccurate.conf --msg "Deposit updates AToken scaled balance part 2" --rule "depositUpdatesUserATokenSuperBalance_sanity" # TIMEOUT 2023
-          # # - PoolAccurate.conf --msg "Deposit cannot change other users scaled balance" --rule "depositCannotChangeOthersATokenSuperBalance" # TIMEOUT 2023
-          # # - PoolAccurate.conf --msg "Index non decreasing part 2 -- timeouting when not split into different patches of methods" --rule _updateIndexesWrapperReachable # TIMEOUT 2023
-          # - ReserveConfiguration.conf
-          # - UserConfigCLI.conf
-          # - StableTokenCLI.conf
-          # - VariableTokenCLI.conf
-          # # - PoolSimpleProperties.conf --msg "Deposit functionality part 1" --rule "cannotDepositInInactiveReserve" # TIMEOUT 2023
-          # # - PoolSimpleProperties.conf --msg "Deposit functionality part 2" --rule "cannotDepositInFrozenReserve" #TIMEOUT 2023
-          # - PoolSimpleProperties.conf --msg "Deposit functionality part 3" --rule "cannotDepositZeroAmount"
-          # - PoolSimpleProperties.conf --msg "Methods reachability part 1" --rule "method_reachability_split_for_CI_01"
-          # - PoolSimpleProperties.conf --msg "Methods reachability part 2" --rule "method_reachability_split_for_CI_02_backUnbacked"
-          # - PoolSimpleProperties.conf --msg "Methods reachability part 3" --rule "method_reachability_split_for_CI_03_repayWithATokens"
-          # # - PoolSimpleProperties.conf --msg "Methods reachability part 4" --rule "method_reachability_split_for_CI_04_repayWithPermit" # TIMEOUT 2023
-          # # - PoolSimpleProperties.conf --msg "Methods reachability part 5" --rule "method_reachability_split_for_CI_05_liquidationCall" # TIMEOUT 2023
-          # - PoolSimpleProperties.conf --msg "Methods reachability part 6" --rule "method_reachability_split_for_CI_06_flashLoan"
-          # - PoolSimpleProperties.conf --msg "Methods reachability part 7" --rule "method_reachability_split_for_CI_07_borrow"
-          # - PoolSimpleProperties.conf --msg "Methods reachability part 8" --rule "method_reachability_split_for_CI_08_supplyWithPermit"
-          # - PoolSimpleProperties.conf --msg "Methods reachability part 9" --rule "method_reachability_split_for_CI_09_rebalanceStableBorrowRate"
-          # # - PoolSimpleProperties.conf --msg "Methods reachability part 10" --rule "method_reachability_split_for_CI_10_repay" # TIMEOUT 2023
-          # # - PoolSimpleProperties.conf --msg "Methods reachability part 11" --rule "method_reachability_split_for_CI_11_flashLoanSimple" # TIMEOUT 2023
-          # - PoolSimpleProperties.conf --msg "Withdraw functionality part 1" --rule "cannotWithdrawFromInactiveReserve"
-          # - PoolSimpleProperties.conf --msg "Withdraw functionality part 2" --rule "cannotWithdrawZeroAmount"
-          # - PoolSimpleProperties.conf --msg "Borrow functionality part 1" --rule "cannotBorrowZeroAmount"
-          # - PoolSimpleProperties.conf --msg "Borrow functionality part 2" --rule "cannotBorrowOnInactiveReserve"
-          # - PoolSimpleProperties.conf --msg "Borrow functionality part 3" --rule "cannotBorrowOnReserveDisabledForBorrowing"
-          # - PoolSimpleProperties.conf --msg "Borrow functionality part 4" --rule "cannotBorrowOnFrozenReserve"
+          - PoolAccurate.conf --msg "Index non decreasing part 4" --rule "liquidityIndexNonDecresingFor_cumulateToLiquidityIndex"
+          # - PoolAccurate.conf --msg "Deposit updates AToken scaled balance part 1" --rule "depositUpdatesUserATokenSuperBalance" # TIMEOUT 2023
+          # - PoolAccurate.conf --msg "Deposit updates AToken scaled balance part 2" --rule "depositUpdatesUserATokenSuperBalance_sanity" # TIMEOUT 2023
+          # - PoolAccurate.conf --msg "Deposit cannot change other users scaled balance" --rule "depositCannotChangeOthersATokenSuperBalance" # TIMEOUT 2023
+          # - PoolAccurate.conf --msg "Index non decreasing part 2 -- timeouting when not split into different patches of methods" --rule _updateIndexesWrapperReachable # TIMEOUT 2023
+          - ReserveConfiguration.conf
+          - UserConfigCLI.conf
+          - StableTokenCLI.conf
+          - VariableTokenCLI.conf
+          # - PoolSimpleProperties.conf --msg "Deposit functionality part 1" --rule "cannotDepositInInactiveReserve" # TIMEOUT 2023
+          # - PoolSimpleProperties.conf --msg "Deposit functionality part 2" --rule "cannotDepositInFrozenReserve" #TIMEOUT 2023
+          - PoolSimpleProperties.conf --msg "Deposit functionality part 3" --rule "cannotDepositZeroAmount"
+          - PoolSimpleProperties.conf --msg "Methods reachability part 1" --rule "method_reachability_split_for_CI_01"
+          - PoolSimpleProperties.conf --msg "Methods reachability part 2" --rule "method_reachability_split_for_CI_02_backUnbacked"
+          - PoolSimpleProperties.conf --msg "Methods reachability part 3" --rule "method_reachability_split_for_CI_03_repayWithATokens"
+          # - PoolSimpleProperties.conf --msg "Methods reachability part 4" --rule "method_reachability_split_for_CI_04_repayWithPermit" # TIMEOUT 2023
+          # - PoolSimpleProperties.conf --msg "Methods reachability part 5" --rule "method_reachability_split_for_CI_05_liquidationCall" # TIMEOUT 2023
+          - PoolSimpleProperties.conf --msg "Methods reachability part 6" --rule "method_reachability_split_for_CI_06_flashLoan"
+          - PoolSimpleProperties.conf --msg "Methods reachability part 7" --rule "method_reachability_split_for_CI_07_borrow"
+          - PoolSimpleProperties.conf --msg "Methods reachability part 8" --rule "method_reachability_split_for_CI_08_supplyWithPermit"
+          - PoolSimpleProperties.conf --msg "Methods reachability part 9" --rule "method_reachability_split_for_CI_09_rebalanceStableBorrowRate"
+          # - PoolSimpleProperties.conf --msg "Methods reachability part 10" --rule "method_reachability_split_for_CI_10_repay" # TIMEOUT 2023
+          # - PoolSimpleProperties.conf --msg "Methods reachability part 11" --rule "method_reachability_split_for_CI_11_flashLoanSimple" # TIMEOUT 2023
+          - PoolSimpleProperties.conf --msg "Withdraw functionality part 1" --rule "cannotWithdrawFromInactiveReserve"
+          - PoolSimpleProperties.conf --msg "Withdraw functionality part 2" --rule "cannotWithdrawZeroAmount"
+          - PoolSimpleProperties.conf --msg "Borrow functionality part 1" --rule "cannotBorrowZeroAmount"
+          - PoolSimpleProperties.conf --msg "Borrow functionality part 2" --rule "cannotBorrowOnInactiveReserve"
+          - PoolSimpleProperties.conf --msg "Borrow functionality part 3" --rule "cannotBorrowOnReserveDisabledForBorrowing"
+          - PoolSimpleProperties.conf --msg "Borrow functionality part 4" --rule "cannotBorrowOnFrozenReserve"

--- a/.github/workflows/certora.yml
+++ b/.github/workflows/certora.yml
@@ -62,30 +62,30 @@ jobs:
           - AToken.conf
           - PoolInvariant.conf --msg "Martins rules with PoolInvariant.conf" --rule "borrowOnlyVariableOrStableRate"
           - PoolInvariant.conf --msg "Index non decreasing part 1" --rule "indexIncreasesMonotonically"
-          - PoolAccurate.conf --msg "Index non decreasing part 3" --rule "indexChangesOnlyWith_updateIndexes" # TIMEOUT 2023
+          - PoolAccurate.conf --msg "Index non decreasing part 3" --rule "indexChangesOnlyWith_updateIndexes" # TIMEOUT 2023 v5.0.5
           - PoolAccurate.conf --msg "Index non decreasing part 4" --rule "liquidityIndexNonDecresingFor_cumulateToLiquidityIndex"
-          - PoolAccurate.conf --msg "Deposit updates AToken scaled balance part 1" --rule "depositUpdatesUserATokenSuperBalance" # TIMEOUT 2023
-          - PoolAccurate.conf --msg "Deposit updates AToken scaled balance part 2" --rule "depositUpdatesUserATokenSuperBalance_sanity" # TIMEOUT 2023
-          - PoolAccurate.conf --msg "Deposit cannot change other users scaled balance" --rule "depositCannotChangeOthersATokenSuperBalance" # TIMEOUT 2023
-          - PoolAccurate.conf --msg "Index non decreasing part 2 -- timeouting when not split into different patches of methods" --rule _updateIndexesWrapperReachable # TIMEOUT 2023
+          - PoolAccurate.conf --msg "Deposit updates AToken scaled balance part 1" --rule "depositUpdatesUserATokenSuperBalance" # TIMEOUT 2023 v5.0.5
+          - PoolAccurate.conf --msg "Deposit updates AToken scaled balance part 2" --rule "depositUpdatesUserATokenSuperBalance_sanity" # TIMEOUT 2023 v5.0.5
+          - PoolAccurate.conf --msg "Deposit cannot change other users scaled balance" --rule "depositCannotChangeOthersATokenSuperBalance" # TIMEOUT 2023 v5.0.5
+          # - PoolAccurate.conf --msg "Index non decreasing part 2 -- timeouting when not split into different patches of methods" --rule _updateIndexesWrapperReachable # TIMEOUT 2023 v5.0.5 and v6.0.0
           - ReserveConfiguration.conf
           - UserConfigCLI.conf
           - StableTokenCLI.conf
           - VariableTokenCLI.conf
-          - PoolSimpleProperties.conf --msg "Deposit functionality part 1" --rule "cannotDepositInInactiveReserve" # TIMEOUT 2023
-          - PoolSimpleProperties.conf --msg "Deposit functionality part 2" --rule "cannotDepositInFrozenReserve" #TIMEOUT 2023
+          - PoolSimpleProperties.conf --msg "Deposit functionality part 1" --rule "cannotDepositInInactiveReserve" # TIMEOUT 2023 v5.0.5 v5.0.5
+          - PoolSimpleProperties.conf --msg "Deposit functionality part 2" --rule "cannotDepositInFrozenReserve" #TIMEOUT 2023 v5.0.5 v5.0.5
           - PoolSimpleProperties.conf --msg "Deposit functionality part 3" --rule "cannotDepositZeroAmount"
           - PoolSimpleProperties.conf --msg "Methods reachability part 1" --rule "method_reachability_split_for_CI_01"
           - PoolSimpleProperties.conf --msg "Methods reachability part 2" --rule "method_reachability_split_for_CI_02_backUnbacked"
           - PoolSimpleProperties.conf --msg "Methods reachability part 3" --rule "method_reachability_split_for_CI_03_repayWithATokens"
-          - PoolSimpleProperties.conf --msg "Methods reachability part 4" --rule "method_reachability_split_for_CI_04_repayWithPermit" # TIMEOUT 2023
-          - PoolSimpleProperties.conf --msg "Methods reachability part 5" --rule "method_reachability_split_for_CI_05_liquidationCall" # TIMEOUT 2023
+          - PoolSimpleProperties.conf --msg "Methods reachability part 4" --rule "method_reachability_split_for_CI_04_repayWithPermit" # TIMEOUT 2023 v5.0.5
+          # - PoolSimpleProperties.conf --msg "Methods reachability part 5" --rule "method_reachability_split_for_CI_05_liquidationCall" # TIMEOUT 2023 v5.0.5 and v6.0.0
           - PoolSimpleProperties.conf --msg "Methods reachability part 6" --rule "method_reachability_split_for_CI_06_flashLoan"
           - PoolSimpleProperties.conf --msg "Methods reachability part 7" --rule "method_reachability_split_for_CI_07_borrow"
           - PoolSimpleProperties.conf --msg "Methods reachability part 8" --rule "method_reachability_split_for_CI_08_supplyWithPermit"
           - PoolSimpleProperties.conf --msg "Methods reachability part 9" --rule "method_reachability_split_for_CI_09_rebalanceStableBorrowRate"
-          - PoolSimpleProperties.conf --msg "Methods reachability part 10" --rule "method_reachability_split_for_CI_10_repay" # TIMEOUT 2023
-          - PoolSimpleProperties.conf --msg "Methods reachability part 11" --rule "method_reachability_split_for_CI_11_flashLoanSimple" # TIMEOUT 2023
+          - PoolSimpleProperties.conf --msg "Methods reachability part 10" --rule "method_reachability_split_for_CI_10_repay" # TIMEOUT 2023 v5.0.5
+          - PoolSimpleProperties.conf --msg "Methods reachability part 11" --rule "method_reachability_split_for_CI_11_flashLoanSimple" # TIMEOUT 2023 v5.0.5
           - PoolSimpleProperties.conf --msg "Withdraw functionality part 1" --rule "cannotWithdrawFromInactiveReserve"
           - PoolSimpleProperties.conf --msg "Withdraw functionality part 2" --rule "cannotWithdrawZeroAmount"
           - PoolSimpleProperties.conf --msg "Borrow functionality part 1" --rule "cannotBorrowZeroAmount"

--- a/.github/workflows/certora.yml
+++ b/.github/workflows/certora.yml
@@ -59,33 +59,33 @@ jobs:
       max-parallel: 16
       matrix:
         rule:
-          # - AToken.conf
+          - AToken.conf
           - PoolInvariant.conf --msg "Martins rules with PoolInvariant.conf" --rule "borrowOnlyVariableOrStableRate"
           - PoolInvariant.conf --msg "Index non decreasing part 1" --rule "indexIncreasesMonotonically"
           - PoolAccurate.conf --msg "Index non decreasing part 3" --rule "indexChangesOnlyWith_updateIndexes" # TIMEOUT 2023
           - PoolAccurate.conf --msg "Index non decreasing part 4" --rule "liquidityIndexNonDecresingFor_cumulateToLiquidityIndex"
-          # - PoolAccurate.conf --msg "Deposit updates AToken scaled balance part 1" --rule "depositUpdatesUserATokenSuperBalance" # TIMEOUT 2023
-          # - PoolAccurate.conf --msg "Deposit updates AToken scaled balance part 2" --rule "depositUpdatesUserATokenSuperBalance_sanity" # TIMEOUT 2023
-          # - PoolAccurate.conf --msg "Deposit cannot change other users scaled balance" --rule "depositCannotChangeOthersATokenSuperBalance" # TIMEOUT 2023
-          # - PoolAccurate.conf --msg "Index non decreasing part 2 -- timeouting when not split into different patches of methods" --rule _updateIndexesWrapperReachable # TIMEOUT 2023
+          - PoolAccurate.conf --msg "Deposit updates AToken scaled balance part 1" --rule "depositUpdatesUserATokenSuperBalance" # TIMEOUT 2023
+          - PoolAccurate.conf --msg "Deposit updates AToken scaled balance part 2" --rule "depositUpdatesUserATokenSuperBalance_sanity" # TIMEOUT 2023
+          - PoolAccurate.conf --msg "Deposit cannot change other users scaled balance" --rule "depositCannotChangeOthersATokenSuperBalance" # TIMEOUT 2023
+          - PoolAccurate.conf --msg "Index non decreasing part 2 -- timeouting when not split into different patches of methods" --rule _updateIndexesWrapperReachable # TIMEOUT 2023
           - ReserveConfiguration.conf
           - UserConfigCLI.conf
           - StableTokenCLI.conf
           - VariableTokenCLI.conf
-          # - PoolSimpleProperties.conf --msg "Deposit functionality part 1" --rule "cannotDepositInInactiveReserve" # TIMEOUT 2023
-          # - PoolSimpleProperties.conf --msg "Deposit functionality part 2" --rule "cannotDepositInFrozenReserve" #TIMEOUT 2023
+          - PoolSimpleProperties.conf --msg "Deposit functionality part 1" --rule "cannotDepositInInactiveReserve" # TIMEOUT 2023
+          - PoolSimpleProperties.conf --msg "Deposit functionality part 2" --rule "cannotDepositInFrozenReserve" #TIMEOUT 2023
           - PoolSimpleProperties.conf --msg "Deposit functionality part 3" --rule "cannotDepositZeroAmount"
           - PoolSimpleProperties.conf --msg "Methods reachability part 1" --rule "method_reachability_split_for_CI_01"
           - PoolSimpleProperties.conf --msg "Methods reachability part 2" --rule "method_reachability_split_for_CI_02_backUnbacked"
           - PoolSimpleProperties.conf --msg "Methods reachability part 3" --rule "method_reachability_split_for_CI_03_repayWithATokens"
-          # - PoolSimpleProperties.conf --msg "Methods reachability part 4" --rule "method_reachability_split_for_CI_04_repayWithPermit" # TIMEOUT 2023
-          # - PoolSimpleProperties.conf --msg "Methods reachability part 5" --rule "method_reachability_split_for_CI_05_liquidationCall" # TIMEOUT 2023
+          - PoolSimpleProperties.conf --msg "Methods reachability part 4" --rule "method_reachability_split_for_CI_04_repayWithPermit" # TIMEOUT 2023
+          - PoolSimpleProperties.conf --msg "Methods reachability part 5" --rule "method_reachability_split_for_CI_05_liquidationCall" # TIMEOUT 2023
           - PoolSimpleProperties.conf --msg "Methods reachability part 6" --rule "method_reachability_split_for_CI_06_flashLoan"
           - PoolSimpleProperties.conf --msg "Methods reachability part 7" --rule "method_reachability_split_for_CI_07_borrow"
           - PoolSimpleProperties.conf --msg "Methods reachability part 8" --rule "method_reachability_split_for_CI_08_supplyWithPermit"
           - PoolSimpleProperties.conf --msg "Methods reachability part 9" --rule "method_reachability_split_for_CI_09_rebalanceStableBorrowRate"
-          # - PoolSimpleProperties.conf --msg "Methods reachability part 10" --rule "method_reachability_split_for_CI_10_repay" # TIMEOUT 2023
-          # - PoolSimpleProperties.conf --msg "Methods reachability part 11" --rule "method_reachability_split_for_CI_11_flashLoanSimple" # TIMEOUT 2023
+          - PoolSimpleProperties.conf --msg "Methods reachability part 10" --rule "method_reachability_split_for_CI_10_repay" # TIMEOUT 2023
+          - PoolSimpleProperties.conf --msg "Methods reachability part 11" --rule "method_reachability_split_for_CI_11_flashLoanSimple" # TIMEOUT 2023
           - PoolSimpleProperties.conf --msg "Withdraw functionality part 1" --rule "cannotWithdrawFromInactiveReserve"
           - PoolSimpleProperties.conf --msg "Withdraw functionality part 2" --rule "cannotWithdrawZeroAmount"
           - PoolSimpleProperties.conf --msg "Borrow functionality part 1" --rule "cannotBorrowZeroAmount"

--- a/.github/workflows/certora.yml
+++ b/.github/workflows/certora.yml
@@ -5,10 +5,12 @@ on:
     branches:
       - master
       - certora
+      - testing-CI
   pull_request:
     branches:
       - master
       - certora
+      - testing-CI
 
   workflow_dispatch:
 
@@ -33,7 +35,7 @@ jobs:
         with: { java-version: '11', java-package: jre }
 
       - name: Install certora cli
-        run: pip install certora-cli
+        run: pip install certora-cli-beta
 
       - name: Install solc
         run: |
@@ -57,36 +59,36 @@ jobs:
       max-parallel: 16
       matrix:
         rule:
-          - AToken.conf
-          - PoolInvariant.conf --msg "Martins rules with PoolInvariant.conf" --rule "borrowOnlyVariableOrStableRate"
-          - PoolInvariant.conf --msg "Index non decreasing part 1" --rule "indexIncreasesMonotonically"
-          # - PoolAccurate.conf --msg "Index non decreasing part 3" --rule "indexChangesOnlyWith_updateIndexes" # TIMEOUT 2023
-          - PoolAccurate.conf --msg "Index non decreasing part 4" --rule "liquidityIndexNonDecresingFor_cumulateToLiquidityIndex"
-          # - PoolAccurate.conf --msg "Deposit updates AToken scaled balance part 1" --rule "depositUpdatesUserATokenSuperBalance" # TIMEOUT 2023
-          # - PoolAccurate.conf --msg "Deposit updates AToken scaled balance part 2" --rule "depositUpdatesUserATokenSuperBalance_sanity" # TIMEOUT 2023
-          # - PoolAccurate.conf --msg "Deposit cannot change other users scaled balance" --rule "depositCannotChangeOthersATokenSuperBalance" # TIMEOUT 2023
-          # - PoolAccurate.conf --msg "Index non decreasing part 2 -- timeouting when not split into different patches of methods" --rule _updateIndexesWrapperReachable # TIMEOUT 2023
-          - ReserveConfiguration.conf
-          - UserConfigCLI.conf
-          - StableTokenCLI.conf
-          - VariableTokenCLI.conf
-          # - PoolSimpleProperties.conf --msg "Deposit functionality part 1" --rule "cannotDepositInInactiveReserve" # TIMEOUT 2023
-          # - PoolSimpleProperties.conf --msg "Deposit functionality part 2" --rule "cannotDepositInFrozenReserve" #TIMEOUT 2023
-          - PoolSimpleProperties.conf --msg "Deposit functionality part 3" --rule "cannotDepositZeroAmount"
-          - PoolSimpleProperties.conf --msg "Methods reachability part 1" --rule "method_reachability_split_for_CI_01"
-          - PoolSimpleProperties.conf --msg "Methods reachability part 2" --rule "method_reachability_split_for_CI_02_backUnbacked"
-          - PoolSimpleProperties.conf --msg "Methods reachability part 3" --rule "method_reachability_split_for_CI_03_repayWithATokens"
-          # - PoolSimpleProperties.conf --msg "Methods reachability part 4" --rule "method_reachability_split_for_CI_04_repayWithPermit" # TIMEOUT 2023
-          # - PoolSimpleProperties.conf --msg "Methods reachability part 5" --rule "method_reachability_split_for_CI_05_liquidationCall" # TIMEOUT 2023
-          - PoolSimpleProperties.conf --msg "Methods reachability part 6" --rule "method_reachability_split_for_CI_06_flashLoan"
-          - PoolSimpleProperties.conf --msg "Methods reachability part 7" --rule "method_reachability_split_for_CI_07_borrow"
-          - PoolSimpleProperties.conf --msg "Methods reachability part 8" --rule "method_reachability_split_for_CI_08_supplyWithPermit"
-          - PoolSimpleProperties.conf --msg "Methods reachability part 9" --rule "method_reachability_split_for_CI_09_rebalanceStableBorrowRate"
-          # - PoolSimpleProperties.conf --msg "Methods reachability part 10" --rule "method_reachability_split_for_CI_10_repay" # TIMEOUT 2023
-          # - PoolSimpleProperties.conf --msg "Methods reachability part 11" --rule "method_reachability_split_for_CI_11_flashLoanSimple" # TIMEOUT 2023
-          - PoolSimpleProperties.conf --msg "Withdraw functionality part 1" --rule "cannotWithdrawFromInactiveReserve"
-          - PoolSimpleProperties.conf --msg "Withdraw functionality part 2" --rule "cannotWithdrawZeroAmount"
-          - PoolSimpleProperties.conf --msg "Borrow functionality part 1" --rule "cannotBorrowZeroAmount"
-          - PoolSimpleProperties.conf --msg "Borrow functionality part 2" --rule "cannotBorrowOnInactiveReserve"
-          - PoolSimpleProperties.conf --msg "Borrow functionality part 3" --rule "cannotBorrowOnReserveDisabledForBorrowing"
-          - PoolSimpleProperties.conf --msg "Borrow functionality part 4" --rule "cannotBorrowOnFrozenReserve"
+          # - AToken.conf
+          # - PoolInvariant.conf --msg "Martins rules with PoolInvariant.conf" --rule "borrowOnlyVariableOrStableRate"
+          # - PoolInvariant.conf --msg "Index non decreasing part 1" --rule "indexIncreasesMonotonically"
+          - PoolAccurate.conf --msg "Index non decreasing part 3" --rule "indexChangesOnlyWith_updateIndexes" # TIMEOUT 2023
+          # - PoolAccurate.conf --msg "Index non decreasing part 4" --rule "liquidityIndexNonDecresingFor_cumulateToLiquidityIndex"
+          # # - PoolAccurate.conf --msg "Deposit updates AToken scaled balance part 1" --rule "depositUpdatesUserATokenSuperBalance" # TIMEOUT 2023
+          # # - PoolAccurate.conf --msg "Deposit updates AToken scaled balance part 2" --rule "depositUpdatesUserATokenSuperBalance_sanity" # TIMEOUT 2023
+          # # - PoolAccurate.conf --msg "Deposit cannot change other users scaled balance" --rule "depositCannotChangeOthersATokenSuperBalance" # TIMEOUT 2023
+          # # - PoolAccurate.conf --msg "Index non decreasing part 2 -- timeouting when not split into different patches of methods" --rule _updateIndexesWrapperReachable # TIMEOUT 2023
+          # - ReserveConfiguration.conf
+          # - UserConfigCLI.conf
+          # - StableTokenCLI.conf
+          # - VariableTokenCLI.conf
+          # # - PoolSimpleProperties.conf --msg "Deposit functionality part 1" --rule "cannotDepositInInactiveReserve" # TIMEOUT 2023
+          # # - PoolSimpleProperties.conf --msg "Deposit functionality part 2" --rule "cannotDepositInFrozenReserve" #TIMEOUT 2023
+          # - PoolSimpleProperties.conf --msg "Deposit functionality part 3" --rule "cannotDepositZeroAmount"
+          # - PoolSimpleProperties.conf --msg "Methods reachability part 1" --rule "method_reachability_split_for_CI_01"
+          # - PoolSimpleProperties.conf --msg "Methods reachability part 2" --rule "method_reachability_split_for_CI_02_backUnbacked"
+          # - PoolSimpleProperties.conf --msg "Methods reachability part 3" --rule "method_reachability_split_for_CI_03_repayWithATokens"
+          # # - PoolSimpleProperties.conf --msg "Methods reachability part 4" --rule "method_reachability_split_for_CI_04_repayWithPermit" # TIMEOUT 2023
+          # # - PoolSimpleProperties.conf --msg "Methods reachability part 5" --rule "method_reachability_split_for_CI_05_liquidationCall" # TIMEOUT 2023
+          # - PoolSimpleProperties.conf --msg "Methods reachability part 6" --rule "method_reachability_split_for_CI_06_flashLoan"
+          # - PoolSimpleProperties.conf --msg "Methods reachability part 7" --rule "method_reachability_split_for_CI_07_borrow"
+          # - PoolSimpleProperties.conf --msg "Methods reachability part 8" --rule "method_reachability_split_for_CI_08_supplyWithPermit"
+          # - PoolSimpleProperties.conf --msg "Methods reachability part 9" --rule "method_reachability_split_for_CI_09_rebalanceStableBorrowRate"
+          # # - PoolSimpleProperties.conf --msg "Methods reachability part 10" --rule "method_reachability_split_for_CI_10_repay" # TIMEOUT 2023
+          # # - PoolSimpleProperties.conf --msg "Methods reachability part 11" --rule "method_reachability_split_for_CI_11_flashLoanSimple" # TIMEOUT 2023
+          # - PoolSimpleProperties.conf --msg "Withdraw functionality part 1" --rule "cannotWithdrawFromInactiveReserve"
+          # - PoolSimpleProperties.conf --msg "Withdraw functionality part 2" --rule "cannotWithdrawZeroAmount"
+          # - PoolSimpleProperties.conf --msg "Borrow functionality part 1" --rule "cannotBorrowZeroAmount"
+          # - PoolSimpleProperties.conf --msg "Borrow functionality part 2" --rule "cannotBorrowOnInactiveReserve"
+          # - PoolSimpleProperties.conf --msg "Borrow functionality part 3" --rule "cannotBorrowOnReserveDisabledForBorrowing"
+          # - PoolSimpleProperties.conf --msg "Borrow functionality part 4" --rule "cannotBorrowOnFrozenReserve"


### PR DESCRIPTION
In this PR we test whether the new version `certora-cli-beta 6.0.0` overpowers the version `certora-cli 5.0.5`. As described on [Slack here](https://certora.slack.com/archives/C05R36BCY92/p1702554190190589?thread_ts=1702549104.563319&cid=C05R36BCY92), it does. So we switch to `certora-cli-beta` until production stable `certora-cli` also has version 6.0.0.